### PR TITLE
Popover: prevent href="#" scroll to top of page

### DIFF
--- a/dist/js/rcue-util.js
+++ b/dist/js/rcue-util.js
@@ -41,7 +41,7 @@ var RCUE = RCUE || {};
 		});
 		
 		// Bind Close Icon to Toggle Dispaly
-		allpopovers.on('click', function() {
+		allpopovers.on('click', function(e) {
 			var $this = $(this);
 				$title = $this.next('.popover').find('.popover-title');
 			
@@ -52,6 +52,9 @@ var RCUE = RCUE || {};
 			$title.find('span').on('click', function() {
 				$this.popover('toggle');
 			});
+			
+			// Prevent href="#" page scroll to top
+			e.preventDefault();
 		});
 	};
 	


### PR DESCRIPTION
Hey Robb,

So bootstrap's default behavior of popups does not prevent page from scrolling to top on href="#" links. So I've added e.preventDefault() to our .on('click') event. Please review the latest changes.

Thanks,
~ JK ~
