### PR TITLE
Bug Fix: Move initialization in rcue-util.js to HTML

### DIFF
--- a/dist/js/rcue-util.js
+++ b/dist/js/rcue-util.js
@@ -2,76 +2,67 @@
 var RCUE = RCUE || {};
 
 
-// Util: RCUE Combo-box Input Change on Selection
+// Util: Dropdown Combo-box Input Change on Selection
 (function($) {
-	RCUE.combobox = function( selector ) {
-		$( selector ).each(function() {
-			var input = $( this ).find('.form-control'),
-					menu = $( this ).find('.dropdown-menu'),
-					links = menu.find('li a');
-			
-			$( links ).on('click', function() {
-				input.val( $(this).html() );
-			});
-			
-		});	
-	};
-	
-	// Initialize on DOM ready
-	$( RCUE.combobox('.input-group-rcue') );
+  RCUE.combobox = function( selector ) {
+    $( selector ).each(function() {
+      var input = $( this ).find('.form-control'),
+          menu = $( this ).find('.dropdown-menu'),
+          links = menu.find('li a');
+      
+      $( links ).on('click', function() {
+        input.val( $(this).html() );
+      });
+    }); 
+  };
 })(jQuery);
 
+
+// Util: Dropdown Multi-select Plugin
+// http://davidstutz.github.io/bootstrap-multiselect/
+(function($) {
+  RCUE.multiselect = function( selector ) {
+    $(selector).multiselect({
+      buttonWidth: '100%',
+      buttonContainer: '<span class="btn-gr btn-group-rcue btn-block" />',
+      buttonClass: 'btn btn-default btn-block'
+    });
+  };
+})(jQuery);
 
 
 // Util: RCUE Popovers
 // Add data-close="true" to insert close X icon
 (function($) {
-	RCUE.popovers = function( selector ) {
-		var allpopovers = $(selector);
-		
-		// Initialize
-		allpopovers.popover();
-		
-		// Add close icons
-		allpopovers.filter('[data-close=true]').each(function(index, element) {
-			var $this = $(element),
-				title = $this.attr('data-original-title') + '&nbsp;<span />';
+  RCUE.popovers = function( selector ) {
+    var allpopovers = $(selector);
+    
+    // Initialize
+    allpopovers.popover();
+    
+    // Add close icons
+    allpopovers.filter('[data-close=true]').each(function(index, element) {
+      var $this = $(element),
+        title = $this.attr('data-original-title') + '&nbsp;<span />';
 
-			$this.attr('data-original-title', title);
-		});
-		
-		// Bind Close Icon to Toggle Dispaly
-		allpopovers.on('click', function(e) {
-			var $this = $(this);
-				$title = $this.next('.popover').find('.popover-title');
-			
-			// Only if data-close is true add class "x" to title for right padding
-			$title.find('span').parent('.popover-title').addClass('x');
-			
-			// Bind x icon to close popover
-			$title.find('span').on('click', function() {
-				$this.popover('toggle');
-			});
-			
-			// Prevent href="#" page scroll to top
-			e.preventDefault();
-		});
-	};
-	
-	$( RCUE.popovers('[data-toggle=popover]') );
-})(jQuery);
-
-
-// Util: Bootstrap Multiselect Plugin
-// http://davidstutz.github.io/bootstrap-multiselect/
-(function($) {
-	RCUE.multiselect = function( selector ) {
-		$(selector).multiselect({
-			buttonWidth: '100%',
-			buttonContainer: '<span class="btn-group btn-group-rcue btn-block" />',
-			buttonClass: 'btn btn-default btn-block'
-		});
-	};
-	
-	$( RCUE.multiselect('.multiselect') );
+      $this.attr('data-original-title', title);
+    });
+    
+    // Bind Close Icon to Toggle Dispaly
+    allpopovers.on('click', function(e) {
+      var $this = $(this);
+        $title = $this.next('.popover').find('.popover-title');
+      
+      // Only if data-close is true add class "x" to title for right padding
+      $title.find('span').parent('.popover-title').addClass('x');
+      
+      // Bind x icon to close popover
+      $title.find('span').on('click', function() {
+        $this.popover('toggle');
+      });
+      
+      // Prevent href="#" page scroll to top
+      e.preventDefault();
+    });
+  };
 })(jQuery);

--- a/tests/dropdowns.html
+++ b/tests/dropdowns.html
@@ -90,5 +90,10 @@
       </div><!-- /row -->
     </div><!-- /container -->
     <script src="../dist/js/rcue-util.js"></script>
+    <script>
+      // Initialize Combo-box and Multi-select
+      RCUE.combobox('.input-group-rcue');
+      RCUE.multiselect('.multiselect');
+    </script>
   </body>
 </html>

--- a/tests/infotip.html
+++ b/tests/infotip.html
@@ -75,5 +75,9 @@
       </div><!-- /row -->
     </div><!-- /container -->
     <script src="../dist/js/rcue-util.js"></script>
+    <script>
+      // Initialize Popovers
+      RCUE.popovers('[data-toggle=popover]')
+    </script>
   </body>
 </html>

--- a/tests/modals.html
+++ b/tests/modals.html
@@ -54,6 +54,5 @@
         </div><!-- /col -->
       </div><!-- /row -->
     </div><!-- /container -->
-    <script src="../dist/js/rcue-util.js"></script>
   </body>
 </html>

--- a/tests/popovers.html
+++ b/tests/popovers.html
@@ -46,5 +46,9 @@
       </div><!-- /row -->
     </div><!-- /container -->
     <script src="../dist/js/rcue-util.js"></script>
+    <script>
+      // Initialize Popovers
+      RCUE.popovers('[data-toggle=popover]')
+    </script>
   </body>
 </html>

--- a/tests/tooltip.html
+++ b/tests/tooltip.html
@@ -49,7 +49,7 @@
       </div><!-- /row -->
     </div><!-- /container -->
     <script>
-      // tooltip demo
+      // Initialize Tooltip
       $('.tooltip-demo').tooltip({
         selector: "[data-toggle=tooltip]",
         container: "body"


### PR DESCRIPTION
In addition:
Removed rcue-util.js reference in modals.html, since no utils are being
used.
Cleaned up white space formatting in rcue-util.js to use 2 white spaces
than tabs.
