### PR TITLE
Added explicit dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,8 @@
   "author": "Red Hat",
   "license": "Apache-2.0",
   "dependencies": {
+    "bootstrap": "~3.3.7",
+    "font-awesome": "~4.6.3",
     "patternfly": "~3.16.0"
   },
   "devDependencies": {
@@ -19,6 +21,15 @@
     "matchdep": "~0.3.0",
     "nsp": "^2.6.1",
     "patternfly-eng-release": "~3.16.0"
+  },
+  "optionalDependencies": {
+    "bootstrap-datepicker": "~1.6.4",
+    "bootstrap-select": "~1.10.0",
+    "bootstrap-switch": "~3.3.2",
+    "bootstrap-touchspin": "~3.1.1",
+    "c3": "~0.4.11",
+    "eonasdan-bootstrap-datetimepicker": "~4.15.35",
+    "patternfly-bootstrap-combobox": "~1.1.7"
   },
   "description": "The [Red Hat Common User Experience (RCUE)](http://rcue-uxd.itos.redhat.com/) project was created to promote design commonality across all of Red Hat’s Enterprise product offerings.",
   "repository": {


### PR DESCRIPTION
Added explicit dependencies so npm will create a flat node_modules structure.

During a release, the npm-shrinkwrap file is removed in order to create a new file with the latest dependencies. In this scenario, npm install places dependencies under node_modules/patternfly/node_modules, which prevents the build from succeeding. Creating explicit dependencies forces dependencies to be placed in the root node_modules directory where patternfly expects them to be.

This will allow me to remove my workaround to manually move dependencies from node_modules/patternfly/node_modules to node_modules.