### PR TITLE
Build Jekyll dependencies using bundler

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -7,6 +7,8 @@ var mountFolder = function (connect, dir) {
 };
 
 module.exports = function (grunt) {
+  'use strict';
+
   // load all grunt tasks
   require('matchdep').filterDev('grunt-*').forEach(grunt.loadNpmTasks);
 
@@ -38,6 +40,16 @@ module.exports = function (grunt) {
           },
           port: 9001
         }
+      }
+    },
+    run: {
+      options: {
+      },
+      bundleInstall: {
+        cmd: 'bundle',
+        args: [
+          'install'
+        ]
       }
     },
     copy: {
@@ -80,7 +92,8 @@ module.exports = function (grunt) {
     },
     jekyll: {
       options: {
-        src: 'node_modules/patternfly/tests/pages'
+        src: 'node_modules/patternfly/tests/pages',
+        bundleExec: 'true'
       },
       tests: {
         options: {
@@ -148,6 +161,7 @@ module.exports = function (grunt) {
   });
 
   grunt.registerTask('build', [
+    'run:bundleInstall',
     'copy',
     'jekyll',
     'less',

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "grunt-contrib-watch": "~0.5.3",
     "grunt-css-count": "^0.3.0",
     "grunt-jekyll": "^0.4.2",
+    "grunt-run": "^0.6.0",
     "matchdep": "~0.3.0",
     "nsp": "^2.6.1",
     "patternfly-eng-release": "~3.23.1"


### PR DESCRIPTION
This change is inspired by patternfly's Gruntfile.js and uses
grunt-run to install/update gem bundles used by Jekyll in the
subsequent build step.

The Jekyll build step has been updated with bundleExec: true
to build using `bundle exec`.

As a little side change, this also enables strict mode for
the Grunt configuration closure (module.exports).

Fixes: #70