### PR TITLE
Bump patternfly-eng-release version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ before_install:
   - rvm install 2.3.1
   - if [[ `npm -v` != 3* ]]; then npm i -g npm@3; fi
   - npm install -g bower grunt-cli
-  - npm install git+https://github.com/patternfly/patternfly-eng-release.git
+  - npm install patternfly-eng-release
 
 install: true
 

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "grunt-run": "^0.6.0",
     "matchdep": "~0.3.0",
     "nsp": "^2.6.1",
-    "patternfly-eng-release": "3.26.2"
+    "patternfly-eng-release": "^3.26.35"
   },
   "optionalDependencies": {
     "bootstrap-datepicker": "~1.6.4",


### PR DESCRIPTION
Bumped patternfly-eng-release version to sync with latest.

Should also install version from package.json, instead of always grabbing the latest patternfly-eng-release.

Note that this is not a semantic release, just syncing.