### PR TITLE
Bumped patternfly-eng-release version

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "grunt-run": "^0.6.0",
     "matchdep": "~0.3.0",
     "nsp": "^2.6.1",
-    "patternfly-eng-release": "^3.26.35"
+    "patternfly-eng-release": "3.26.44"
   },
   "optionalDependencies": {
     "bootstrap-datepicker": "~1.6.4",


### PR DESCRIPTION
Created a new patternfly-eng-release script to generate release notes via a GitHub API. 

This will be run as part of the automated release, triggered by the PatternFly semantic release. However, release notes can still be edited manually, after the release has been created.

The release notes will look similar to below, updated for the latest PatternFly version.
https://github.com/redhat-rcue/rcue/releases/tag/v3.29.6

Changes to the patternfly-eng-release can be found here:
https://github.com/patternfly/patternfly-eng-release/pull/58