### PR TITLE
have grunt copy patternfly images along with fonts and less files

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -63,6 +63,8 @@ module.exports = function (grunt) {
           {expand: true, cwd: 'node_modules/patternfly/dist/fonts/', src: ['**'], dest: 'dist/fonts/'},
           // copy PatternFly less files
           {expand: true, cwd: 'node_modules/patternfly/less/', src: ['**'], dest: 'less/lib/patternfly/'},
+          // copy PatternFly images
+          {expand: true, cwd: 'node_modules/patternfly/dist/img/', src: ['**'], dest: 'dist/img'},
         ],
       },
     },


### PR DESCRIPTION
Addresses issue #81 

When trying to consume rcue via project dependency, and using
webpack to pull assets to an application from a node_module, all
of the images need to be present or the webpack will fail.  Copy
all the images across on each update to make sure changes and
additions get included automatically. 