### PR TITLE
Add bootstrap-slider as an optional dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
   "optionalDependencies": {
     "bootstrap-datepicker": "~1.6.4",
     "bootstrap-select": "~1.10.0",
+    "bootstrap-slider": "^9.9.0",
     "bootstrap-switch": "~3.3.2",
     "bootstrap-touchspin": "~3.1.1",
     "c3": "~0.4.11",


### PR DESCRIPTION
Need to add bootstrap-slider as an optional dependency in order for build to succeed -- tested locally.

Note that PatternFly has fixed the relative paths issue introduced with bootstrap-slider
https://github.com/patternfly/patternfly/pull/859